### PR TITLE
fix #57 by changing href for GitHub corner in index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -39,7 +39,7 @@
     <a
       target="_blank"
       rel="noreferrer noopener"
-      href="https://freesound-player.netlify.app"
+      href="https://github.com/amilajack/freesound-player"
       class="github-corner"
       aria-label="View source on GitHub">
       <svg


### PR DESCRIPTION
This pull request should fix #57. I just changed the `href` for the [GitHub corner](https://github.com/tholman/github-corners) in `index.html` so that it points to [`freesound-player`](https://github.com/amilajack/freesound-player) instead of [`freesound-player`'s current address](https://freesound-player.netlify.app/).

I made some weird errors in #58 so we can just look at this pull request in regard to fixing #57.