### PR TITLE
start implementation of keyboard shortcuts using tinykey for #66

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-scripts": "3.4.3",
     "react-wavesurfer.js": "^0.0.2",
     "tailwindcss": "^1.8.10",
+    "tinykeys": "^1.1.0",
     "wavesurfer.js": "4.1.1"
   },
   "devDependencies": {

--- a/src/Sound.js
+++ b/src/Sound.js
@@ -1,3 +1,4 @@
+import tinykeys from "tinykeys";
 import React, { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import localForage from "localforage";
@@ -79,7 +80,19 @@ export default function Sound(props) {
       }
     };
     fetchSound();
-  }, [id, props, freeSound]);
+    const unsubscribe = tinykeys(window, {
+      Space: (event) => {
+        event.preventDefault();
+        setIsPlaying((i) => !i);
+      },
+      d: () => {
+        if (isLoggedIn) downloadSound(sound);
+      },
+    });
+    return () => {
+      unsubscribe();
+    };
+  }, [freeSound, id, isLoggedIn, props, sound]);
 
   return (
     <div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11326,6 +11326,11 @@ tiny-warning@^1.0.0, tiny-warning@^1.0.3:
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
+tinykeys@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tinykeys/-/tinykeys-1.1.0.tgz#156672f7d6774194a302f7c38418b01451391aae"
+  integrity sha512-0xhPcaVmE6F1ZNC2m/w9BVBT/05x4UJ2cGhJLGOCOE8z/AVNVi9qUSI1UUpj7ba0OTHL7aMum3pZioPVO9qkpw==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"


### PR DESCRIPTION
This pull request lays the groundwork for handling #66.

I've only added the shortcut to play and pause the current sound when a user presses `Space`, since that's the only one of the listed shortcuts I was able to figure out how to add.

> - [x] Spacebar plays the current sound
> - [ ]  Pressing numbers seek the current sound (similar to youtube)
> - [ ] cmd + ? opens shortcuts panel

On the plus side, I did manage to add a semi-functioning shortcut that allows users to download sounds when they press the `d` key on their keyboard. If they are not logged in, it does absolutely nothing, as it should, but if they are logged in, pressing `d` opens the 'allow downloads?' dialog box and what appears to be full download functionality.

- [x] d key allows users to download sounds if they are logged in

It's only semi-functioning because there's a weird sort of glitching effect that causes the download button to appear and reappear rapidly on page load. On the plus side, this effect ceases after a couple of seconds, and that glitch only appears if a user is logged in; otherwise, there's no download button, and that visual glitch doesn't seem to occur.

One last point: I did do `git reset --soft HEAD~2` to undo the two commits I made for #81 as @amilajack [recommended to me in #58](https://github.com/amilajack/freesound-player/pull/58#discussion_r492413400); however, the changed files are still part of the commit in this pull request: so, even though the pre-commit check branch's commits aren't in this pull request, the changes I made for that branch are.

@akshara-sun, if you haven't run into an issue like this already, @amilajack might have a fix for it that he can explain to both of us for our benefit.