### PR TITLE
fix: remove deprecated ionicons script

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -59,7 +59,8 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-    <script src="https://unpkg.com/ionicons@5.1.2/dist/ionicons.js"></script>
+    <script type="module" src="https://unpkg.com/ionicons@5.1.2/dist/ionicons/ionicons.esm.js"></script>
+    <script nomodule="" src="https://unpkg.com/ionicons@5.1.2/dist/ionicons/ionicons.js"></script>
   </body>
 </html>
 


### PR DESCRIPTION
Fix the following warning from ionicons:

<img width="928" alt="Screen Shot 2020-10-04 at 3 48 22 PM" src="https://user-images.githubusercontent.com/6374832/95028926-09ba6a80-0659-11eb-9e50-ecaa630a243c.png">