### PR TITLE
hide crop, download and play/pause buttons while sound loads to close #89

### DIFF
--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /// <reference types="cypress" />
 // ***********************************************************
 // This example plugins/index.js can be used to load plugins

--- a/src/Sound.js
+++ b/src/Sound.js
@@ -112,7 +112,7 @@ export default function Sound(props) {
         </button>
       )}
       {sound.previews && (
-        <section>
+        <React.Fragment>
           <Waveform
             waveColor="#FBDC57"
             backgroundColor="black"
@@ -132,7 +132,7 @@ export default function Sound(props) {
               <ion-icon name="play-circle-sharp" />
             )}
           </button>
-        </section>
+        </React.Fragment>
       )}
       <SoundList
         header="Pack"

--- a/src/Sound.js
+++ b/src/Sound.js
@@ -112,24 +112,28 @@ export default function Sound(props) {
         </button>
       )}
       {sound.previews && (
-        <Waveform
-          waveColor="#FBDC57"
-          backgroundColor="black" barWidth={1}
-          cursorColor="white"  cursorWidth={1}
-          onFinish={() => setIsPlaying(false)}
-          playing={isPlaying}
-          src={sound.previews["preview-lq-mp3"]}
-        />
+        <section>
+          <Waveform
+            waveColor="#FBDC57"
+            backgroundColor="black"
+            barWidth={1}
+            cursorColor="white"
+            cursorWidth={1}
+            onFinish={() => setIsPlaying(false)}
+            playing={isPlaying}
+            src={sound.previews["preview-lq-mp3"]}
+          />
+          <ion-icon name="crop-sharp"></ion-icon>
+          <ion-icon name="download-sharp"></ion-icon>
+          <button onClick={handlePlayingAndPausing}>
+            {isPlaying ? (
+              <ion-icon name="pause-circle-sharp"></ion-icon>
+            ) : (
+              <ion-icon name="play-circle-sharp" />
+            )}
+          </button>
+        </section>
       )}
-      <ion-icon name="crop-sharp"></ion-icon>
-      <ion-icon name="download-sharp"></ion-icon>
-      <button onClick={handlePlayingAndPausing}>
-        {isPlaying ? (
-          <ion-icon name="pause-circle-sharp"></ion-icon>
-        ) : (
-          <ion-icon name="play-circle-sharp" />
-        )}
-      </button>
       <SoundList
         header="Pack"
         tracks={packSounds}

--- a/src/Sound.js
+++ b/src/Sound.js
@@ -112,7 +112,7 @@ export default function Sound(props) {
         </button>
       )}
       {sound.previews && (
-        <React.Fragment>
+        <>
           <Waveform
             waveColor="#FBDC57"
             backgroundColor="black"
@@ -132,7 +132,7 @@ export default function Sound(props) {
               <ion-icon name="play-circle-sharp" />
             )}
           </button>
-        </React.Fragment>
+        </>
       )}
       <SoundList
         header="Pack"


### PR DESCRIPTION
Closes #89 by hiding crop, download and play/pause buttons while a sound is loading.

This was a simple change: I just grouped together all the elements that we don't want to appear until the sound loads into a single `<section>` element and [had that `<section>` element only appear if `sound.previews` was not falsy](https://github.com/amilajack/freesound-player/commit/cc951ff20e40d7b08b061b46a6d9a0d0536c849d#diff-855d1e7866ea6a1e0913c9388d287101R114).

This branch also adds `/* eslint-disable */` to [`/freesound-player/cypress/plugins/index.js`](https://github.com/amilajack/freesound-player/commit/cc951ff20e40d7b08b061b46a6d9a0d0536c849d#r42961449) to quell error messages that appeared in the terminal for me after initially trying to make the sole commit in this branch and another commit in a branch I created earlier.