### PR TITLE
fix only enabling shortcuts if body has focus

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -65,7 +65,7 @@
     <title>Freesound</title>
   </head>
 
-  <body id="body">
+  <body>
     <a
       target="_blank"
       rel="noreferrer noopener"

--- a/public/index.html
+++ b/public/index.html
@@ -65,7 +65,7 @@
     <title>Freesound</title>
   </head>
 
-  <body>
+  <body id="body">
     <a
       target="_blank"
       rel="noreferrer noopener"

--- a/src/Sound.js
+++ b/src/Sound.js
@@ -87,20 +87,22 @@ export default function Sound(props) {
     };
     fetchSound();
   }, [id, freeSound]);
-
+  /* eslint-disable-next-line */
   useEffect(() => {
-    const unsubscribe = tinykeys(window, {
-      Space: (event) => {
-        event.preventDefault();
-        setIsPlaying((i) => !i);
-      },
-      d: () => {
-        if (isLoggedIn) downloadSound(sound);
-      },
-    });
-    return () => {
-      unsubscribe();
-    };
+    if (document.activeElement.id === "body") {
+      const unsubscribe = tinykeys(window, {
+        Space: (event) => {
+          event.preventDefault();
+          setIsPlaying((i) => !i);
+        },
+        d: () => {
+          if (isLoggedIn) downloadSound(sound);
+        },
+      });
+      return () => {
+        unsubscribe();
+      };
+    }
   });
 
   return (

--- a/src/Sound.js
+++ b/src/Sound.js
@@ -87,22 +87,22 @@ export default function Sound(props) {
     };
     fetchSound();
   }, [id, freeSound]);
-  /* eslint-disable-next-line */
   useEffect(() => {
-    if (document.activeElement.id === "body") {
-      const unsubscribe = tinykeys(window, {
-        Space: (event) => {
+    const unsubscribe = tinykeys(window, {
+      Space: (event) => {
+        if (document.activeElement === document.body) {
           event.preventDefault();
           setIsPlaying((i) => !i);
-        },
-        d: () => {
-          if (isLoggedIn) downloadSound(sound);
-        },
-      });
-      return () => {
-        unsubscribe();
-      };
-    }
+        }
+      },
+      d: () => {
+        if (isLoggedIn && document.activeElement === document.body)
+          downloadSound(sound);
+      },
+    });
+    return () => {
+      unsubscribe();
+    };
   });
 
   return (

--- a/src/Sound.js
+++ b/src/Sound.js
@@ -90,15 +90,17 @@ export default function Sound(props) {
   useEffect(() => {
     const unsubscribe = tinykeys(window, {
       Space: (event) => {
+        // Shortcuts should only work
         if (document.activeElement === document.body) {
-          event.preventDefault();
-          setIsPlaying((i) => !i);
-        }
+          event.preventDefault(); // if we're on the main
+          setIsPlaying((i) => !i); // section of the app,
+        } // and not if, say, we are searching for a sound.
       },
       d: () => {
+        // As stated above, shortcuts should only work
         if (isLoggedIn && document.activeElement === document.body)
-          downloadSound(sound);
-      },
+          downloadSound(sound); // when on the main section of the
+      }, // app, and not, for example, while searching.
     });
     return () => {
       unsubscribe();


### PR DESCRIPTION
This tries to fix #104 by checking if the `<body>` is the `document.activeElement` before allowing use of the keyboard shortcuts we previously added.