### PR TITLE
close #182 by adjusting hover and non-hover opacity of Featured link

### DIFF
--- a/src/Nav.js
+++ b/src/Nav.js
@@ -28,7 +28,9 @@ function Nav({
             <a href="/">Explore</a>
           </li>
           <li className="mr-6">
-            <a href="/featured">Featured</a>
+            <a className="hover:opacity-100 opacity-50" href="/featured">
+              Featured
+            </a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
This pull request closes #182 if we merge it. It gives the Featured link currently on the homepage of this application a className of "opacity-50" so it appears lower in opacity when a cursor is not over it; when a mouse hovers over the Featured link, its opacity will return to 100% thanks to the "hover:opacity-100" className.﻿
