### PR TITLE
fix: fix #212 by only rendering Pack <SoundList /> component if nonempty

### DIFF
--- a/src/Sound.js
+++ b/src/Sound.js
@@ -180,7 +180,7 @@ export default function Sound(props) {
           </div>
         </>
       )}
-      {packSounds[0] && (
+      {packSounds.length && (
         <SoundList
           tracks={packSounds}
           selectedTrack={sound?.id || packSounds[0]?.id || 0}

--- a/src/Sound.js
+++ b/src/Sound.js
@@ -180,14 +180,16 @@ export default function Sound(props) {
           </div>
         </>
       )}
-      <SoundList
-        header="Pack"
-        tracks={packSounds}
-        selectedTrack={sound?.id || packSounds[0]?.id || 0}
-        setSelectedTrack={() => {}}
-        onSoundClick={() => window.scrollTo(0, 0)}
-        className="pb-16"
-      />
+      {packSounds[0] && (
+        <SoundList
+          tracks={packSounds}
+          selectedTrack={sound?.id || packSounds[0]?.id || 0}
+          setSelectedTrack={() => {}}
+          onSoundClick={() => window.scrollTo(0, 0)}
+          header="Pack"
+          className="pb-16"
+        />
+      )}
       <SoundList
         header="Similar"
         tracks={similarSounds}


### PR DESCRIPTION
This pull request fixes #212 if we merge it. It fixes the issue of empty Pack <SoundList /> components displaying using the relatively straightforward approach of only displaying a Pack <SoundList /> component if `packSounds` has a first element, i.e., if `packSounds` is not empty.﻿
