### PR TITLE
close #222 by adding an end-to-end Cypress test for URL updating during search

### DIFF
--- a/cypress/integration/sample_spec.ts
+++ b/cypress/integration/sample_spec.ts
@@ -22,6 +22,21 @@ describe("Home Page", () => {
   });
 });
 
+describe("Search functionality", () => {
+  beforeEach(() => {
+    setupServerMocks()
+  })
+
+  it("checks that search updates the url correctly ", () => {
+    cy.visit("/");
+    cy
+      .get(`[name="sound-search"]`)
+      .type('hello')
+      .should('have.value', 'hello')
+    cy.url().should('include', '/search?q=hello')
+  });
+});
+
 describe("Sound Page", () => {
   beforeEach(() => {
     setupServerMocks()

--- a/cypress/integration/sample_spec.ts
+++ b/cypress/integration/sample_spec.ts
@@ -30,7 +30,7 @@ describe("Search functionality", () => {
   it("checks that search updates the url correctly ", () => {
     cy.visit("/");
     cy
-      .get(`[name="sound-search"]`)
+      .get(`[data-e2e-id="search-input"]`)
       .type('hello')
       .should('have.value', 'hello')
     cy.url().should('include', '/search?q=hello')

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -5,6 +5,7 @@ export default function Input({ ...props }) {
     <input
       {...props}
       className="appearance-none block placeholder-secondary text-secondary bg-primary border rounded p-1 leading-tight focus:outline-none pl-4"
+      data-e2e-id="search-input"
     />
   );
 }


### PR DESCRIPTION
This pull request closes #222 if we decide to merge it by adding an end-to-end Cypress test that checks whether the URL updates appropriately after entering a search term in the search bar.﻿
