### PR TITLE
fix #216 by commenting out redundant and nonfunctional elements

### DIFF
--- a/src/Nav.js
+++ b/src/Nav.js
@@ -24,14 +24,14 @@ function Nav({
     <nav className="flex justify-between items-center py-4 md:justify-start md:space-x-10">
       <div className="md:flex items-center justify-start space-x-8 md:flex-1 lg:w-0">
         <ul className="flex">
-          <li className="mr-6">
-            <a href="/">Explore</a>
+          {/* <li className="mr-6"> // Removing on Tuesday, November 24, 2020, due to
+            <a href="/">Explore</a> // lack of functionality - Hamir
           </li>
           <li className="mr-6">
             <a className="hover:opacity-100 opacity-50" href="/featured">
               Featured
             </a>
-          </li>
+          </li> */}
         </ul>
       </div>
       <div className="md:flex space-x-2 justify-between items-center">

--- a/src/Sound.js
+++ b/src/Sound.js
@@ -1,7 +1,7 @@
 import DOMPurify from "dompurify";
 import {
   caretDownOutline,
-  cropSharp,
+  // cropSharp, // Removing on Tuesday, November 24, 2020
   downloadSharp,
   pauseCircleSharp,
   playCircleSharp,
@@ -137,7 +137,7 @@ export default function Sound(props) {
           <div className="flex justfify-between py-3">
             {/* Download and edit buttons */}
             <div className="w-6/12 space-x-3">
-              <IonIcon size="large" icon={downloadSharp} />
+              {/* <IonIcon size="large" icon={downloadSharp} /> */}
               <button
                 onClick={handlePlayingAndPausing}
                 className="focus:outline-none"
@@ -151,10 +151,10 @@ export default function Sound(props) {
             </div>
             {/* Download stats and Play */}
             <div className="w-6/12 text-right space-x-3 flex justify-end items-center">
-              <Button>
-                <IonIcon icon={cropSharp} />
+              {/* <Button>  // Removing on Tuesday, November 24, 2020, due to
+                <IonIcon icon={cropSharp} />  // lack of functionality - Hamir
                 <a>Edit</a>
-              </Button>
+              </Button> */}
               {isLoggedIn && loadingState === 1 && (
                 <Button onClick={() => downloadSound(sound)}>
                   <IonIcon icon={downloadSharp} />


### PR DESCRIPTION
This pull requests fixes #216 by commenting out the `Explore` and `Featured` links that were at the top lefthand corner of the homepage and the `<IonIcon size="large" icon={downloadSharp} />` icon and `Edit` button that appeared immediately below waveforms on sound pages in `Nav.js` and `Sound.js` since they were nonfunctional or redundant.﻿
