### PR TITLE
close #126 by adding react-helmet integration to update tab titles

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "postcss-cli": "^8.3.0",
     "react": "17.0.1",
     "react-dom": "17.0.1",
+    "react-helmet": "^6.1.0",
     "react-modal": "^3.12.1",
     "react-router-dom": "5.2.0",
     "react-scripts": "^4.0.1",

--- a/src/Sound.js
+++ b/src/Sound.js
@@ -1,10 +1,11 @@
 import DOMPurify from "dompurify";
-import { pauseCircleSharp, playCircleSharp } from "ionicons/icons";
+import { Helmet } from "react-helmet";
 import { IonIcon } from "@ionic/react";
 import localForage from "localforage";
+import { pauseCircleSharp, playCircleSharp } from "ionicons/icons";
+import tinykeys from "tinykeys";
 import { useParams } from "react-router-dom";
 import React, { useEffect, useState } from "react";
-import tinykeys from "tinykeys";
 import Waveform from "react-wavesurfer.js";
 import SoundList from "./SoundList";
 import Description from "./components/Description";
@@ -110,6 +111,10 @@ export default function Sound(props) {
 
   return (
     <>
+      <Helmet>
+        <title>{sound.name}</title>
+        <meta name="description" content="Name of current sound" />
+      </Helmet>
       <h1
         data-e2e-id="sound-title"
         className="text-4xl md:text-5xl mb-4 text-left"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13108,7 +13108,7 @@ react-error-overlay@^6.0.7, react-error-overlay@^6.0.8:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.8.tgz#474ed11d04fc6bda3af643447d85e9127ed6b5de"
   integrity sha512-HvPuUQnLp5H7TouGq3kzBeioJmXms1wHy9EGjz2OURWBp4qZO6AfGEcnxts1D/CbwPLRAgTMPCEgYhA3sEM4vw==
 
-react-fast-compare@^3.0.1, react-fast-compare@^3.2.0:
+react-fast-compare@^3.0.1, react-fast-compare@^3.1.1, react-fast-compare@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
@@ -13123,6 +13123,16 @@ react-helmet-async@^1.0.2:
     prop-types "^15.7.2"
     react-fast-compare "^3.2.0"
     shallowequal "^1.1.0"
+
+react-helmet@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-6.1.0.tgz#a750d5165cb13cf213e44747502652e794468726"
+  integrity sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.7.2"
+    react-fast-compare "^3.1.1"
+    react-side-effect "^2.1.0"
 
 react-hotkeys@2.0.0:
   version "2.0.0"
@@ -13281,6 +13291,11 @@ react-scripts@^4.0.1:
     workbox-webpack-plugin "5.1.4"
   optionalDependencies:
     fsevents "^2.1.3"
+
+react-side-effect@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.1.tgz#66c5701c3e7560ab4822a4ee2742dee215d72eb3"
+  integrity sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==
 
 react-sizeme@^2.6.7:
   version "2.6.12"


### PR DESCRIPTION
This pull request closes #126 if we merge it. It adds react-helmet integration so that different sound page tab titles update to show their sound's name instead of generic title.﻿
